### PR TITLE
Harden Standard.site production sync

### DIFF
--- a/apps/web/public/favicon-dark.svg
+++ b/apps/web/public/favicon-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-	<circle cx="12" cy="12" r="12" fill="#14b8a6"/>
-	<path fill="#111827" fill-rule="evenodd" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20zm0-4-4-2V6L6 7v10l6 3 6-3v-4l-2-1 2-1V7l-6-3v14zm4-4-2-1v4l2-1v-2zm0-6-2-1v4l2-1V8z" clip-rule="evenodd"/>
+<svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+	<circle cx="12" cy="12" fill="#14b8a6" r="12"/>
+	<path clip-rule="evenodd" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20zm0-4-4-2V6L6 7v10l6 3 6-3v-4l-2-1 2-1V7l-6-3v14zm4-4-2-1v4l2-1v-2zm0-6-2-1v4l2-1V8z" fill="#111827" fill-rule="evenodd"/>
 </svg>

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-	<circle cx="12" cy="12" r="12" fill="#fff"/>
-	<path fill="#0f766e" fill-rule="evenodd" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20zm0-4-4-2V6L6 7v10l6 3 6-3v-4l-2-1 2-1V7l-6-3v14zm4-4-2-1v4l2-1v-2zm0-6-2-1v4l2-1V8z" clip-rule="evenodd"/>
+<svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+	<circle cx="12" cy="12" fill="#fff" r="12"/>
+	<path clip-rule="evenodd" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20zm0-4-4-2V6L6 7v10l6 3 6-3v-4l-2-1 2-1V7l-6-3v14zm4-4-2-1v4l2-1v-2zm0-6-2-1v4l2-1V8z" fill="#0f766e" fill-rule="evenodd"/>
 </svg>

--- a/apps/web/scripts/sync-standard-site.test.ts
+++ b/apps/web/scripts/sync-standard-site.test.ts
@@ -7,7 +7,9 @@ import {
 	getDocumentUri,
 	isValidRecordKey,
 	mergeOwnedDocumentFields,
+	parsePublishedPost,
 	planReconciliation,
+	recordSyncedDocumentUri,
 	toPlainText,
 } from './sync-standard-site.ts';
 
@@ -31,6 +33,39 @@ test('extractPortableContent rejects missing frontmatter boundary', () => {
 	assert.throws(
 		() => extractPortableContent('broken.mdoc', 'Hello world'),
 		/broken.mdoc is missing frontmatter/,
+	);
+});
+
+test('parsePublishedPost rejects missing published metadata', () => {
+	assert.throws(
+		() =>
+			parsePublishedPost(
+				'untitled.mdoc',
+				`---
+publishedAt: 2024-01-20
+isDraft: false
+---
+Hello.
+`,
+			),
+		/untitled.mdoc is missing title/,
+	);
+});
+
+test('parsePublishedPost rejects invalid record keys', () => {
+	assert.throws(
+		() =>
+			parsePublishedPost(
+				'.mdoc',
+				`---
+title: Hello
+publishedAt: 2024-01-20
+isDraft: false
+---
+Hello.
+`,
+			),
+		/.mdoc has an invalid ATProto record key/,
 	);
 });
 
@@ -167,6 +202,30 @@ test('planReconciliation fails on unexpected existing record key', () => {
 				],
 			}),
 		/manual cleanup/,
+	);
+});
+
+test('recordSyncedDocumentUri records only matching document AT-URIs', () => {
+	const documentsBySlug = new Map<string, string>();
+
+	recordSyncedDocumentUri(
+		documentsBySlug,
+		'hello-world',
+		'at://did:plc:example/site.standard.document/hello-world',
+	);
+
+	assert.equal(
+		documentsBySlug.get('hello-world'),
+		'at://did:plc:example/site.standard.document/hello-world',
+	);
+	assert.throws(
+		() =>
+			recordSyncedDocumentUri(
+				documentsBySlug,
+				'hello-world',
+				'at://did:plc:example/site.standard.document/generated-key',
+			),
+		/Expected document URI/,
 	);
 });
 

--- a/apps/web/scripts/sync-standard-site.ts
+++ b/apps/web/scripts/sync-standard-site.ts
@@ -118,8 +118,17 @@ export function getDocumentUri(did: string, slug: string): string {
 
 export function assertExpectedDocumentUri(slug: string, uri: string): void {
 	if (getRkey(uri) !== slug) {
-		throw new Error(`${uri} has unexpected record key for ${slug}`);
+		throw new Error(`Expected document URI for ${slug}, received ${uri}`);
 	}
+}
+
+export function recordSyncedDocumentUri(
+	documentsBySlug: Map<string, string>,
+	slug: string,
+	uri: string,
+): void {
+	assertExpectedDocumentUri(slug, uri);
+	documentsBySlug.set(slug, uri);
 }
 
 export function compareOwnedDocumentFields(
@@ -313,39 +322,51 @@ export async function loadPublishedPosts(): Promise<Array<PublishedPost>> {
 
 	for (const filename of filenames) {
 		const source = await readFile(new URL(filename, POSTS_DIR), 'utf8');
-		const slug = basename(filename, '.mdoc');
-
-		if (!source.startsWith('---\n')) {
-			continue;
-		}
-
-		const frontmatterEnd = source.indexOf('\n---\n', 4);
-		if (frontmatterEnd === -1) {
-			continue;
-		}
-
-		const frontmatter = source.slice(4, frontmatterEnd);
-		const fields = parseSimpleFrontmatter(frontmatter);
-
-		if (fields.isDraft === 'true') {
-			continue;
-		}
-
-		const portableContent = source.slice(frontmatterEnd + '\n---\n'.length);
-
-		if (!fields.publishedAt || !fields.title) {
-			continue;
-		}
-
-		posts.push({
-			portableContent,
-			publishedAt: fields.publishedAt,
-			slug,
-			title: fields.title,
-		});
+		const post = parsePublishedPost(filename, source);
+		if (post) posts.push(post);
 	}
 
 	return posts;
+}
+
+export function parsePublishedPost(
+	filename: string,
+	source: string,
+): PublishedPost | null {
+	const slug = basename(filename, '.mdoc');
+	if (!isValidRecordKey(slug)) {
+		throw new Error(`${filename} has an invalid ATProto record key`);
+	}
+
+	if (!source.startsWith('---\n')) {
+		throw new Error(`${filename} is missing frontmatter`);
+	}
+
+	const frontmatterEnd = source.indexOf('\n---\n', 4);
+	if (frontmatterEnd === -1) {
+		throw new Error(`${filename} is missing frontmatter`);
+	}
+
+	const frontmatter = source.slice(4, frontmatterEnd);
+	const fields = parseSimpleFrontmatter(frontmatter);
+
+	if (fields.isDraft === 'true') {
+		return null;
+	}
+
+	if (!fields.title) {
+		throw new Error(`${filename} is missing title`);
+	}
+	if (!fields.publishedAt) {
+		throw new Error(`${filename} is missing publishedAt`);
+	}
+
+	return {
+		portableContent: source.slice(frontmatterEnd + '\n---\n'.length),
+		publishedAt: fields.publishedAt,
+		slug,
+		title: fields.title,
+	};
 }
 
 function parseSimpleFrontmatter(
@@ -551,7 +572,7 @@ async function executePlan(
 				method: 'POST',
 			},
 		);
-		documentsBySlug.set(item.slug, result.uri);
+		recordSyncedDocumentUri(documentsBySlug, item.slug, result.uri);
 	}
 
 	for (const item of plan.updates) {
@@ -571,7 +592,7 @@ async function executePlan(
 				method: 'POST',
 			},
 		);
-		documentsBySlug.set(item.slug, result.uri);
+		recordSyncedDocumentUri(documentsBySlug, item.slug, result.uri);
 	}
 
 	for (const item of plan.deletes) {


### PR DESCRIPTION
## Summary
- Fail loudly when published Standard.site post files have missing metadata or invalid record keys.
- Validate returned document AT-URIs before adding them to the generated manifest.
- Sort favicon SVG attributes so production `check` is not blocked by Biome assist rules.

## Verification
- `pnpm --filter @lukebennett/web test:standard-site`
- `pnpm --filter @lukebennett/web check`
- `pnpm --filter @lukebennett/web build`
- `pnpm --filter @lukebennett/web standard-site:sync`
- `pnpm --filter @lukebennett/web run build:production` reaches `Set STANDARD_SITE_APP_PASSWORD` after `check`, as expected locally without production credentials.
