### PR TITLE
Share one manifest contract between Standard.site writer and reader

### DIFF
--- a/apps/web/scripts/sync-standard-site.ts
+++ b/apps/web/scripts/sync-standard-site.ts
@@ -3,6 +3,11 @@ import { basename } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import * as z from 'zod';
 
+import {
+	serializeStandardSiteManifest,
+	standardSitePublicationUri,
+} from '../src/lib/standard-site.ts';
+
 type PublishedPost = {
 	portableContent: string;
 	publishedAt: string;
@@ -22,7 +27,7 @@ type DocumentRecord = {
 	description: string;
 	path: `/posts/${string}`;
 	publishedAt: string;
-	site: typeof PUBLICATION_URI;
+	site: typeof standardSitePublicationUri;
 	textContent: string;
 	title: string;
 };
@@ -70,8 +75,6 @@ const POSTS_DIR = new URL('content/posts/', APP_DIR);
 const GENERATED_DIR = new URL('src/generated/', APP_DIR);
 const MANIFEST_URL = new URL('src/generated/standard-site.json', APP_DIR);
 const COLLECTION = 'site.standard.document';
-const PUBLICATION_URI =
-	'at://did:plc:3z5ja7l2rhnmtr2bni5dyfe7/site.standard.publication/3mnqwgvxn372f';
 const DEFAULT_IDENTIFIER = 'lukebennett.dev';
 
 export function extractPortableContent(
@@ -184,7 +187,7 @@ export function planReconciliation({
 	for (const record of existingRecords) {
 		const value = record.value ?? {};
 		if (
-			value.site !== PUBLICATION_URI ||
+			value.site !== standardSitePublicationUri ||
 			typeof value.path !== 'string' ||
 			!value.path.startsWith('/posts/')
 		) {
@@ -253,7 +256,7 @@ export function buildDocumentRecord(post: PublishedPost): DocumentRecord {
 		description: truncateDescription(textContent),
 		path: `/posts/${post.slug}`,
 		publishedAt: new Date(`${post.publishedAt}T00:00:00.000Z`).toISOString(),
-		site: PUBLICATION_URI,
+		site: standardSitePublicationUri,
 		textContent,
 		title: post.title,
 	};
@@ -269,16 +272,7 @@ async function writeManifest(
 	await mkdir(GENERATED_DIR, { recursive: true });
 	await writeFile(
 		MANIFEST_URL,
-		`${JSON.stringify(
-			{
-				documentsBySlug: Object.fromEntries(
-					[...documentsBySlug.entries()].sort(([a], [b]) => a.localeCompare(b)),
-				),
-				publicationUri: PUBLICATION_URI,
-			},
-			null,
-			2,
-		)}\n`,
+		serializeStandardSiteManifest(documentsBySlug),
 		'utf8',
 	);
 }

--- a/apps/web/src/lib/standard-site.test.ts
+++ b/apps/web/src/lib/standard-site.test.ts
@@ -7,6 +7,7 @@ import test from 'node:test';
 import {
 	getStandardSiteDocumentUri,
 	loadStandardSiteManifest,
+	serializeStandardSiteManifest,
 	standardSitePublicationUri,
 } from './standard-site.ts';
 
@@ -91,4 +92,58 @@ test('reads document URIs from valid manifest', async () => {
 	} finally {
 		await rm(dir, { force: true, recursive: true });
 	}
+});
+
+test('serializeStandardSiteManifest round-trips through loadStandardSiteManifest', async () => {
+	const dir = await mkdtemp(join(tmpdir(), 'standard-site-'));
+	const manifestPath = join(dir, 'standard-site.json');
+	const documentsBySlug = new Map([
+		[
+			'hello-world',
+			'at://did:plc:3z5ja7l2rhnmtr2bni5dyfe7/site.standard.document/hello-world',
+		],
+		[
+			'another-post',
+			'at://did:plc:3z5ja7l2rhnmtr2bni5dyfe7/site.standard.document/another-post',
+		],
+	]);
+
+	try {
+		await writeFile(
+			manifestPath,
+			serializeStandardSiteManifest(documentsBySlug),
+			'utf8',
+		);
+
+		const manifest = loadStandardSiteManifest({
+			manifestPath,
+			requireManifest: false,
+		});
+
+		assert.deepEqual(
+			manifest.documentsBySlug,
+			Object.fromEntries(documentsBySlug),
+		);
+		assert.equal(manifest.publicationUri, standardSitePublicationUri);
+	} finally {
+		await rm(dir, { force: true, recursive: true });
+	}
+});
+
+test('serializeStandardSiteManifest sorts slugs and ends with a trailing newline', () => {
+	const serialized = serializeStandardSiteManifest(
+		new Map([
+			[
+				'zebra',
+				'at://did:plc:3z5ja7l2rhnmtr2bni5dyfe7/site.standard.document/zebra',
+			],
+			[
+				'apple',
+				'at://did:plc:3z5ja7l2rhnmtr2bni5dyfe7/site.standard.document/apple',
+			],
+		]),
+	);
+
+	assert.ok(serialized.endsWith('\n'));
+	assert.ok(serialized.indexOf('"apple"') < serialized.indexOf('"zebra"'));
 });

--- a/apps/web/src/lib/standard-site.ts
+++ b/apps/web/src/lib/standard-site.ts
@@ -5,14 +5,26 @@ import * as z from 'zod';
 export const standardSitePublicationUri =
 	'at://did:plc:3z5ja7l2rhnmtr2bni5dyfe7/site.standard.publication/3mnqwgvxn372f';
 
-const StandardSiteManifestSchema = z
+export const StandardSiteManifestSchema = z
 	.object({
 		documentsBySlug: z.record(z.string(), z.string().startsWith('at://')),
 		publicationUri: z.literal(standardSitePublicationUri),
 	})
 	.readonly();
 
-type StandardSiteManifest = z.infer<typeof StandardSiteManifestSchema>;
+export type StandardSiteManifest = z.infer<typeof StandardSiteManifestSchema>;
+
+export function serializeStandardSiteManifest(
+	documentsBySlug: Map<string, string>,
+): string {
+	const manifest = StandardSiteManifestSchema.parse({
+		documentsBySlug: Object.fromEntries(
+			[...documentsBySlug.entries()].sort(([a], [b]) => a.localeCompare(b)),
+		),
+		publicationUri: standardSitePublicationUri,
+	});
+	return `${JSON.stringify(manifest, null, 2)}\n`;
+}
 
 type ManifestOptions = {
 	manifestPath?: string;


### PR DESCRIPTION
## Problem

The generated manifest (`src/generated/standard-site.json`) had its shape and the publication URI declared independently in two places: the writer (`scripts/sync-standard-site.ts`, with its own `PUBLICATION_URI` constant and hand-built JSON) and the reader (`src/lib/standard-site.ts`, with the Zod schema). Nothing proved the writer emitted a shape the reader would accept — skew would only surface at runtime, in production.

## Solution

`src/lib/standard-site.ts` becomes the single contract module. It now exports `StandardSiteManifestSchema`, the `StandardSiteManifest` type, and `serializeStandardSiteManifest(documentsBySlug)`, which validates through the schema before producing the JSON. The writer imports `standardSitePublicationUri` and the serializer, dropping its duplicate constant and inline JSON construction. The publication URI is now declared once.

Serializer output is byte-identical to the previous inline writer (same sort order, 2-space indent, trailing newline), so `standard-site.json` will not churn. The file-path resolution on each side is left as-is.

## Verification

- `pnpm --filter @lukebennett/web test:standard-site` — 21 tests pass (added serializer round-trip + formatting tests; existing `buildDocumentRecord` site assertion unchanged).
- `pnpm --filter @lukebennett/web check` — clean.

Part of an architecture review pass; sibling PRs cover the AT Protocol module, Cloud Image preview, and renderer registry.