### PR TITLE
Render Cloud Image editor preview through runtime CloudImage

### DIFF
--- a/apps/web/src/lib/keystatic/component-block/cloud-image.tsx
+++ b/apps/web/src/lib/keystatic/component-block/cloud-image.tsx
@@ -1,31 +1,33 @@
-/** @jsxRuntime classic */
 import { component, fields } from '@keystatic/core';
-// biome-ignore lint/correctness/noUnusedImports: React is used by the classic JSX runtime.
-import * as React from 'react';
+
+import { CloudImage } from '../renderers/cloud-image';
 
 export const cloudImage = component({
 	label: 'Cloud Image',
 	preview({ fields }) {
 		const src = fields.src.value;
 
+		// `CloudImage` calls `new URL(src)` and throws on any not-yet-valid URL
+		// (empty, whitespace-only, or missing protocol), so guard while the
+		// author is still typing.
+		if (!URL.canParse(src)) {
+			return (
+				<figure style={{ margin: 0 }}>
+					<span style={{ color: '#6b7280', fontSize: 12 }}>
+						No image URL yet
+					</span>
+				</figure>
+			);
+		}
+
 		return (
-			<figure style={{ margin: 0 }}>
-				<img
-					alt={fields.alt.value}
-					src={src}
-					style={{
-						display: 'block',
-						maxHeight: 368,
-						maxWidth: '100%',
-						objectFit: 'contain',
-					}}
-				/>
-				{fields.priority.value ? (
-					<figcaption style={{ fontSize: 12, marginTop: 8 }}>
-						Priority image
-					</figcaption>
-				) : null}
-			</figure>
+			<CloudImage
+				alt={fields.alt.value}
+				height={fields.height.value}
+				priority={fields.priority.value}
+				src={src}
+				width={fields.width.value}
+			/>
 		);
 	},
 	schema: {


### PR DESCRIPTION
## Problem

"Cloud Image" had two rendering paths that drifted: the Keystatic editor component-block `preview` rendered a bespoke plain `<img>`, while production rendered through the `CloudImage` (`@unpic/react`) runtime component with the real sizing rules (MAX_WIDTH clamping, breakpoints, fit). The editor preview misrepresented what shipped.

## Solution

The editor `preview` now renders through the same runtime `CloudImage` component, so what the author sees matches production. A small guard (`URL.canParse(src)`) falls back to a placeholder while the URL is still being typed, since `CloudImage` throws on an invalid URL. The field schema is unchanged — it remains the single source of the fields; only the second rendering path is removed.

The classic JSX pragma and explicit React import were dropped in favour of the project's default automatic runtime (consistent with the other renderer files).

Note: the preview-only "Priority image" figcaption is gone; the `priority` field's affordance is carried by its schema label/description, and in production it correctly drives eager loading.

## Verification

- `pnpm --filter @lukebennett/web check` — prettier, biome, `tsc --noEmit` clean.
- `pnpm --filter @lukebennett/web build` — astro build completes.

Part of an architecture review pass; sibling PRs cover the AT Protocol module, manifest contract, and renderer registry.