### PR TITLE
Consolidate Keystatic renderers into a single registry factory

### DIFF
--- a/apps/web/src/lib/keystatic/document-renderer.tsx
+++ b/apps/web/src/lib/keystatic/document-renderer.tsx
@@ -2,13 +2,19 @@ import {
 	type DocumentRendererProps,
 	DocumentRenderer as KeystaticDocumentRenderer,
 } from '@keystatic/core/renderer';
-import { highlighter } from '../highlighter';
-import { componentBlockRenderers, getDocumentRenderers } from './renderers';
+import type { Highlighter } from 'shiki';
 
-export function DocumentRenderer(props: DocumentRendererProps) {
+import { highlighter as defaultHighlighter } from '../highlighter';
+import { createKeystaticRenderers } from './renderers';
+
+export function DocumentRenderer({
+	highlighter = defaultHighlighter,
+	...props
+}: DocumentRendererProps & { highlighter?: Highlighter }) {
+	const registry = createKeystaticRenderers(highlighter);
 	const {
-		componentBlocks = componentBlockRenderers,
-		renderers = getDocumentRenderers(highlighter),
+		componentBlocks = registry.componentBlocks,
+		renderers = registry.renderers,
 		...consumerProps
 	} = props;
 

--- a/apps/web/src/lib/keystatic/renderers/index.tsx
+++ b/apps/web/src/lib/keystatic/renderers/index.tsx
@@ -10,38 +10,37 @@ import { InlineCode } from './inline-code';
 import { Link } from './link';
 
 /**
- * Returns Keystatic document renderers for Code, Headings etc.
+ * Single registry for all Keystatic renderers. Returns both the
+ * component-block renderers and the document block/inline renderers, with the
+ * Shiki highlighter injected as a dependency.
  */
-export function getDocumentRenderers(
-	highlighter: Highlighter,
-): DocumentRendererProps['renderers'] {
+export function createKeystaticRenderers(highlighter: Highlighter): {
+	componentBlocks: InferRenderersForComponentBlocks<typeof componentBlocks>;
+	renderers: DocumentRendererProps['renderers'];
+} {
 	return {
-		block: {
-			code(props) {
-				return <Code {...props} highlighter={highlighter} />;
-			},
-			heading(props) {
-				return <Heading {...props} />;
+		componentBlocks: {
+			cloudImage(props) {
+				return <CloudImage {...props} />;
 			},
 		},
-		inline: {
-			code(props) {
-				return <InlineCode {...props} />;
+		renderers: {
+			block: {
+				code(props) {
+					return <Code {...props} highlighter={highlighter} />;
+				},
+				heading(props) {
+					return <Heading {...props} />;
+				},
 			},
-			link(props) {
-				return <Link {...props} />;
+			inline: {
+				code(props) {
+					return <InlineCode {...props} />;
+				},
+				link(props) {
+					return <Link {...props} />;
+				},
 			},
 		},
 	};
 }
-
-/**
- * Returns renderers for Keystatic component blocks.
- */
-export const componentBlockRenderers: InferRenderersForComponentBlocks<
-	typeof componentBlocks
-> = {
-	cloudImage(props) {
-		return <CloudImage {...props} />;
-	},
-};


### PR DESCRIPTION
## Problem

The Keystatic renderer wiring was split: `renderers/index.tsx` exported `getDocumentRenderers(highlighter)` and a separate `componentBlockRenderers` constant, and `document-renderer.tsx` reached for the eager Shiki highlighter singleton and assembled them as defaults. The highlighter dependency was implicit, with no seam to substitute it.

## Solution

`renderers/index.tsx` now exports a single `createKeystaticRenderers(highlighter)` factory returning `{ componentBlocks, renderers }` — one place where every renderer is registered. `DocumentRenderer` gains an optional `highlighter?` prop (defaulting to the singleton), making the dependency explicit and substitutable at one seam. `highlighter.ts`'s eager initialization is unchanged, and all existing call sites (which pass only `document`) are unaffected.

This is the smallest of the architecture-review candidates — a focused locality improvement, not a plugin system.

## Verification

- `pnpm --filter @lukebennett/web check` — prettier, biome, `tsc --noEmit` clean.
- `pnpm --filter @lukebennett/web build` — astro build completes.
- No stale references to the old export names remain.

Part of an architecture review pass; sibling PRs cover the AT Protocol module, manifest contract, and Cloud Image preview.